### PR TITLE
fix #4

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,7 @@ fi
 
 # setup branch
 branch="gh-pages"
-if [[ "$WERCKER_GH_PAGES_REPO" =~ $WERCKER_GIT_OWNER\.github\.(io|com)$ ]]; then
+if [[ "$repo" =~ $WERCKER_GIT_OWNER\/$WERCKER_GIT_OWNER\.github\.(io|com)$ ]]; then
 	branch="master"
 fi
 


### PR DESCRIPTION
We can use the repo value directly from the env variable.

ref: https://github.com/wercker/support/issues/7
