### PR TITLE
Allow overriding branch

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -37,11 +37,16 @@ then
   echo $WERCKER_GH_PAGES_DOMAIN > CNAME
 fi
 
-
-# setup branch
-branch="gh-pages"
-if [[ "$repo" =~ $WERCKER_GIT_OWNER\/$WERCKER_GIT_OWNER\.github\.(io|com)$ ]]; then
-	branch="master"
+# if directory provided, cd to it
+if [ -d "$WERCKER_GH_PAGES_BRANCH" ]
+then
+  branch="$WERCKER_GH_PAGES_BRANCH"
+else
+  # setup branch
+  branch="gh-pages"
+  if [[ "$repo" =~ $WERCKER_GIT_OWNER\/$WERCKER_GIT_OWNER\.github\.(io|com)$ ]]; then
+    branch="master"
+  fi
 fi
 
 

--- a/run.sh
+++ b/run.sh
@@ -22,7 +22,7 @@ info "using github repo \"$repo\""
 # remote path
 remote="https://$WERCKER_GH_PAGES_TOKEN@github.com/$repo.git"
 
-# if directory provided, cd to it
+# if base directory provided, cd to it
 if [ -d "$WERCKER_GH_PAGES_BASEDIR" ]
 then
   cd $WERCKER_GH_PAGES_BASEDIR
@@ -30,6 +30,12 @@ fi
 
 # remove existing commit history
 rm -rf .git
+
+# if source directory provided, cd to it
+if [ -d "$WERCKER_GH_PAGES_SRCDIR" ]
+then
+  cd $WERCKER_GH_PAGES_SRCDIR
+fi
 
 # generate cname file
 if [ -n $WERCKER_GH_PAGES_DOMAIN ]

--- a/run.sh
+++ b/run.sh
@@ -37,8 +37,8 @@ then
   echo $WERCKER_GH_PAGES_DOMAIN > CNAME
 fi
 
-# if directory provided, cd to it
-if [ -d "$WERCKER_GH_PAGES_BRANCH" ]
+# allow branch overrides
+if [ -n "$WERCKER_GH_PAGES_BRANCH" ]
 then
   branch="$WERCKER_GH_PAGES_BRANCH"
 else

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: gh-pages
-version: 0.2.1
+version: 0.2.2
 description: deploy to github pages
 keywords:
   - github

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: gh-pages
-version: 0.2.2
+version: 0.2.3
 description: deploy to github pages
 keywords:
   - github


### PR DESCRIPTION
It's sometimes useful to deploy to a branch other than `gh-pages`. Particularly useful if you're trying to test the output (aka a staging env) before actually pushing it live.